### PR TITLE
updated wdl-common to resolve memory issue on merge_bam_stats

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "workflows/wdl-common"]
 	path = workflows/wdl-common
-	url = https://github.com/PacificBiosciences/wdl-common
+	url = https://github.com/DNAstack/wdl-common


### PR DESCRIPTION
## Description
`wdl-common` was updated to increase memory allocation to resolve issue with `merge_bam_stats` failing.

## Dependencies (Issues/PRs)
[BIOS-1399](https://app.clickup.com/t/9014209604/BIOS-1399)


## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation


## Task Checklist 
- [ ] documentation updated
- [x] `miniwdl check` passed
- [x] `womtool validate` passed


## Testing
### Workflow Engine Tested On
- [ ] HealthOmics, Amazon Web Services
- [ ] Google Cloud Platform, Cromwell
- [ ] Google Cloud Platform
- [ ] Microsoft Azure, Cromwell
- [ ] GA4GH Workflow Execution Service, On Premises and Multi Cloud
- [ ] Other

### Successful Workflow IDs
*