### PR TITLE
Feat: updated `wdl-common` to address `pbsv discover` memory override

### DIFF
--- a/workflows/family.inputs.json
+++ b/workflows/family.inputs.json
@@ -34,5 +34,6 @@
   "humanwgs_family.merge_bam_stats_override_mem_gb": "Int? (optional)",
   "humanwgs_family.hiphase_override_mem_gb": "Int? (optional)",
   "humanwgs_family.pbstarphase_diplotype_override_mem_gb": "Int? (optional)",
+  "humanwgs_family.pbsv_discover_override_mem_gb": "Int? (optional)",
   "humanwgs_family.debug_version": "String? (optional)"
 }

--- a/workflows/family.wdl
+++ b/workflows/family.wdl
@@ -121,7 +121,8 @@ workflow humanwgs_family {
     Int? merge_bam_stats_override_mem_gb
     Int? hiphase_override_mem_gb
     Int? pbstarphase_diplotype_override_mem_gb
-    Int? pbsv_discover_override_mem_gb String? debug_version
+    Int? pbsv_discover_override_mem_gb
+    String? debug_version
   }
 
   call BackendConfiguration.backend_configuration {

--- a/workflows/family.wdl
+++ b/workflows/family.wdl
@@ -48,6 +48,21 @@ workflow humanwgs_family {
     pbsv_call_mem_gb: {
       name: "Override PBSV call memory request (GB)"
     }
+    pbmm2_align_wgs_override_mem_gb: {
+      name: "Override pbmm2_align memory allocation (GB)"
+    }
+    merge_bam_stats_override_mem_gb: {
+      name: "Override merge_bam_stats memory allocation (GB)"
+    }
+    hiphase_override_mem_gb: {
+      name: "Override hiphase memory allocation (GB)"
+    }
+    pbstarphase_diplotype_override_mem_gb: {
+      name: "Override pbstarphase_diplotype memory allocation (GB)"
+    }
+    pbsv_discover_override_mem_gb: {
+      name: "Override PBSV discover memory allocation (GB)"
+    }
     gpu: {
       name: "Use GPU when possible"
     }
@@ -106,8 +121,7 @@ workflow humanwgs_family {
     Int? merge_bam_stats_override_mem_gb
     Int? hiphase_override_mem_gb
     Int? pbstarphase_diplotype_override_mem_gb
-
-    String? debug_version
+    Int? pbsv_discover_override_mem_gb String? debug_version
   }
 
   call BackendConfiguration.backend_configuration {
@@ -136,8 +150,10 @@ workflow humanwgs_family {
         custom_deepvariant_model_tar    = custom_deepvariant_model_tar,
         single_sample                   = single_sample,
         gpu                             = gpu,
+        pbsv_call_mem_gb                = pbsv_call_mem_gb,
         pbmm2_align_wgs_override_mem_gb = pbmm2_align_wgs_override_mem_gb,
         merge_bam_stats_override_mem_gb = merge_bam_stats_override_mem_gb,
+        pbsv_discover_override_mem_gb   = pbsv_discover_override_mem_gb,
         default_runtime_attributes      = default_runtime_attributes
     }
   }

--- a/workflows/singleton.inputs.json
+++ b/workflows/singleton.inputs.json
@@ -22,5 +22,7 @@
   "humanwgs_singleton.merge_bam_stats_override_mem_gb": "Int? (optional)",
   "humanwgs_singleton.hiphase_override_mem_gb": "Int? (optional)",
   "humanwgs_singleton.pbstarphase_diplotype_override_mem_gb": "Int? (optional)",
+  "humanwgs_singleton.pbsv_discover_override_mem_gb": "Int? (optional)",
+  "humanwgs_singleton.pbsv_call_mem_gb": "Int? (optional)",
   "humanwgs_singleton.debug_version": "String? (optional)"
 }

--- a/workflows/singleton.wdl
+++ b/workflows/singleton.wdl
@@ -46,6 +46,24 @@ workflow humanwgs_singleton {
     tertiary_map_file: {
       name: "TSV containing tertiary analysis file paths and thresholds; must match backend"
     }
+    pbsv_call_mem_gb: {
+      name: "Override PBSV call memory request (GB)"
+    }
+    pbmm2_align_wgs_override_mem_gb: {
+      name: "Override pbmm2_align memory allocation (GB)"
+    }
+    merge_bam_stats_override_mem_gb: {
+      name: "Override merge_bam_stats memory allocation (GB)"
+    }
+    hiphase_override_mem_gb: {
+      name: "Override hiphase memory allocation (GB)"
+    }
+    pbstarphase_diplotype_override_mem_gb: {
+      name: "Override pbstarphase_diplotype memory allocation (GB)"
+    }
+    pbsv_discover_override_mem_gb: {
+      name: "Override PBSV discover memory allocation (GB)"
+    }
     gpu: {
       name: "Use GPU when possible"
     }
@@ -100,11 +118,14 @@ workflow humanwgs_singleton {
     String? container_registry
 
     Boolean preemptible = true
+    
+    Int? pbsv_call_mem_gb
 
     Int? pbmm2_align_wgs_override_mem_gb
     Int? merge_bam_stats_override_mem_gb
     Int? hiphase_override_mem_gb
     Int? pbstarphase_diplotype_override_mem_gb
+    Int? pbsv_discover_override_mem_gb
 
     String? debug_version
   }
@@ -129,8 +150,10 @@ workflow humanwgs_singleton {
       custom_deepvariant_model_tar    = custom_deepvariant_model_tar,
       single_sample                   = true,
       gpu                             = gpu,
+      pbsv_call_mem_gb                = pbsv_call_mem_gb,
       pbmm2_align_wgs_override_mem_gb = pbmm2_align_wgs_override_mem_gb,
       merge_bam_stats_override_mem_gb = merge_bam_stats_override_mem_gb,
+      pbsv_discover_override_mem_gb   = pbsv_discover_override_mem_gb,
       default_runtime_attributes      = default_runtime_attributes
   }
 

--- a/workflows/upstream/inputs.json
+++ b/workflows/upstream/inputs.json
@@ -9,6 +9,8 @@
   "upstream.gpu": "Boolean",
   "upstream.pbmm2_align_wgs_override_mem_gb": "Int? (optional)",
   "upstream.merge_bam_stats_override_mem_gb": "Int? (optional)",
+  "upstream.pbsv_discover_override_mem_gb": "Int? (optional)",
+  "upstream.pbsv_call_mem_gb": "Int? (optional)",
   "upstream.default_runtime_attributes": {
     "max_retries": "Int",
     "container_registry": "String",

--- a/workflows/upstream/upstream.wdl
+++ b/workflows/upstream/upstream.wdl
@@ -50,6 +50,12 @@ workflow upstream {
     merge_bam_stats_override_mem_gb: {
       name: "Memory allocation override for merge_bam_stats"
     }
+    pbsv_discover_override_mem_gb: {
+      name: "Memory allocation override for pbsv_discover"
+    }
+    pbsv_call_mem_gb: {
+      name: "Memory allocation override for pbsv_call"
+    }
     default_runtime_attributes: {
       name: "Runtime attribute structure"
     }
@@ -71,6 +77,8 @@ workflow upstream {
 
     Int? pbmm2_align_wgs_override_mem_gb
     Int? merge_bam_stats_override_mem_gb
+    Int? pbsv_discover_override_mem_gb
+    Int? pbsv_call_mem_gb
 
     RuntimeAttributes default_runtime_attributes
   }
@@ -90,9 +98,10 @@ workflow upstream {
     }
     call Pbsv.pbsv_discover {
       input:
-        aligned_bam        = pbmm2_align.aligned_bam,
-        aligned_bam_index  = pbmm2_align.aligned_bam_index,
-        trf_bed            = ref_map["pbsv_tandem_repeat_bed"], # !FileCoercion
+        aligned_bam                   = pbmm2_align.aligned_bam,
+        aligned_bam_index             = pbmm2_align.aligned_bam_index,
+        trf_bed                       = ref_map["pbsv_tandem_repeat_bed"], # !FileCoercion
+        pbsv_discover_override_mem_gb = pbsv_discover_override_mem_gb,
         runtime_attributes = default_runtime_attributes
     }
   }
@@ -212,6 +221,7 @@ workflow upstream {
           ref_name           = ref_map["name"],
           shard_index        = shard_index,
           regions            = region_set,
+          mem_gb             = pbsv_call_mem_gb,
           runtime_attributes = default_runtime_attributes
       }
     }


### PR DESCRIPTION
## Description
Updated `wdl-common` to handle memory override for `pbsv discover`

## Dependencies (Issues/PRs)
NA


## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Documentation


## Task Checklist
- [ ] documentation updated
- [x] `miniwdl check` passed
- [x] `womtool validate` passed


## Testing
### Workflow Engine Tested On
- [ ] HealthOmics, Amazon Web Services
- [ ] Google Cloud Platform, Cromwell
- [ ] Google Cloud Platform
- [ ] Microsoft Azure, Cromwell
- [ ] GA4GH Workflow Execution Service, On Premises and Multi Cloud
- [ ] Other

### Successful Workflow IDs
*